### PR TITLE
feat: send current block summary on peer connected

### DIFF
--- a/src/node.mts
+++ b/src/node.mts
@@ -26,6 +26,7 @@ export class Node {
     this.server = new Server<'inventory' | 'block'>({ port })
       .on('inventory', (...args) => this.queue.schedule(() => this.onNewBlocks(...args)).catch(() => console.error('Inventory handler error')))
       .on('block', this.getBlock.bind(this))
+      .onConnect(peer => peer.send('inventory', this.tail.summary))
 
     console.log(`Node started on port ${port}`)
   }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved CLI command output formatting
  - Pretty-print JSON structures
  - Detailed unknown command messages

- Enhanced P2P server capabilities
  - Added `send` method to ClientInterface
  - Introduced `onConnect` handler


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocketServer"]
  B["setupSocket"]
  C["buildPeerContext"]
  D["onConnect Handler"]
  A -- "connection" --> B
  B -- "valid client" --> C
  C -- "invoke connect" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.mts</strong><dd><code>Improve CLI command outputs and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli.mts

<ul><li>Remove <code>await</code> on <code>node.start</code><br> <li> Use pretty-print JSON for block/mine output<br> <li> Add block not found and unknown command errors<br> <li> Rename block output label (<code>new block</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/2/files#diff-795f9cd3f5b7c419d737cc16d57e6c86dac57b1e2656da6d436645bdbd264fc6">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>p2p.mts</strong><dd><code>Add onConnect and send in P2P Server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/p2p.mts

<ul><li>Extend ClientInterface with <code>send</code> method<br> <li> Introduce <code>onConnect</code> handler and <code>connectHandler</code><br> <li> Refactor <code>buildPeerContext</code> for unified context<br> <li> Invoke <code>onConnect</code> on new peer connections</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/2/files#diff-523dedc7acad3f4a18834f8602270408e63c6690dabf012561306be2e07bd8c8">+33/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

