### PR TITLE
Reject duplicate transaction inputs

### DIFF
--- a/src/infra/node/node.mts
+++ b/src/infra/node/node.mts
@@ -537,6 +537,8 @@ export class Node {
       // validate transactions
       let totalFee = 0
       for (let tx of block.transactions) {
+        this.assertUniqueTransactionInputs(tx)
+
         // assert tx inputs all refer to unspent outputs
         const referencedUTxOuts: (UTxOut | undefined)[] = tx.inputs.map(input => uTxOuts.get(input))
         if (referencedUTxOuts.includes(undefined)) {
@@ -703,6 +705,7 @@ export class Node {
     for (const serializedTx of response.txs) {
       try {
         const incomingTx = Transaction.deserialize(hexBytes(serializedTx))
+        this.assertUniqueTransactionInputs(incomingTx)
 
         // assert tx inputs all refer to unspent outputs
         const referencedUTxOuts: (UTxOut | undefined)[] = incomingTx.inputs.map(input => this.uTxOuts.get(input))
@@ -748,6 +751,17 @@ export class Node {
     }
     if (validTxIds.size > 0) {
       this.server.broadcast({ type: 'txinv', data: { txids: Array.from(validTxIds) } })
+    }
+  }
+
+  private assertUniqueTransactionInputs(tx: Transaction): void {
+    const spentOutputs = new Set<string>()
+    for (const input of tx.inputs) {
+      const outputId = `${input.txid}:${input.index}`
+      if (spentOutputs.has(outputId)) {
+        throw new Error('Transaction contains duplicate inputs')
+      }
+      spentOutputs.add(outputId)
     }
   }
 }

--- a/test/security-duplicate-input.test.mts
+++ b/test/security-duplicate-input.test.mts
@@ -1,0 +1,68 @@
+import { afterEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { Node } from "../src/infra/node/node.mts"
+import { Account } from "../src/domain/transaction/account.mts"
+import { Block } from "../src/domain/block/block.mts"
+import { Transaction, TxIn, TxOut } from "../src/domain/transaction/transaction.mts"
+import { UTxOut } from "../src/domain/transaction/utxo.mts"
+import { COINBASE_REWARD } from "../src/app/config.mts"
+
+describe("security: duplicate transaction inputs", () => {
+  let node: Node | undefined
+
+  afterEach(() => {
+    node?.stop()
+    node = undefined
+  })
+
+  it("rejects a block containing a transaction that spends the same UTXO twice", async () => {
+    const attacker = new Account()
+    const receiver = new Account()
+    node = new Node()
+    node.importAccount(attacker)
+    node.start(0)
+
+    const fundingBlock = await node.mineAsync(new TextEncoder().encode("fund attacker"))
+    assert.ok(fundingBlock)
+
+    const spendable = node.getUnspentOutputs(attacker.publicKey)[0]
+    assert.ok(spendable)
+
+    const maliciousTx = buildDuplicateInputTransaction(attacker, receiver, spendable)
+    const maliciousBlock = await mineBlockWithTransactions(node, attacker, [maliciousTx])
+
+    await node["onNewBlock"](maliciousBlock)
+
+    assert.notEqual(
+      node.current.hash(),
+      maliciousBlock.hash(),
+      "node must not accept a block that counts one UTXO more than once"
+    )
+    assert.equal(node.getBalance(receiver.publicKey), 0)
+  })
+})
+
+function buildDuplicateInputTransaction(attacker: Account, receiver: Account, spendable: UTxOut): Transaction {
+  const tx = new Transaction()
+    .addInput(new TxIn(spendable.txid, spendable.index))
+    .addInput(new TxIn(spendable.txid, spendable.index))
+    .addOutput(new TxOut(spendable.output.amount + 1, receiver.publicKey))
+
+  attacker.signTxIn(tx, 0)
+  attacker.signTxIn(tx, 1)
+  return tx
+}
+
+async function mineBlockWithTransactions(node: Node, miner: Account, transactions: Transaction[]): Promise<Block> {
+  const block = node.current.generate({ difficulty: node["getCurrentDifficulty"]() })
+  const coinbase = Transaction.buildCoinbaseTx(miner.publicKey, COINBASE_REWARD, block.height)
+
+  assert.equal(block.addTransaction(coinbase), true)
+  for (const tx of transactions) {
+    assert.equal(block.addTransaction(tx), true)
+  }
+
+  const mined = await block.mine()
+  assert.ok(mined)
+  return mined
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test for spending the same UTXO twice in one transaction
- reject duplicate transaction inputs in block validation and mempool intake

## Verification
- pnpm exec tsx --test test/security-duplicate-input.test.mts
- pnpm test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reject duplicate transaction inputs

- Enforce validation in blocks and mempool

- Add duplicate-spend regression test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tx["Incoming transaction"]
  check["Duplicate input check"]
  reject["Reject invalid transaction or block"]
  accept["Continue UTXO validation"]
  tx -- "validate inputs" --> check
  check -- "duplicate found" --> reject
  check -- "unique inputs" --> accept
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node.mts</strong><dd><code>Enforce unique transaction inputs in node validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/node/node.mts

<ul><li>Adds <code>assertUniqueTransactionInputs</code> helper.<br> <li> Rejects repeated <code>txid:index</code> inputs.<br> <li> Applies checks during block validation.<br> <li> Applies checks during peer transaction intake.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/9/files#diff-b9ef608958cb7a976ad2967c87ee24d48cfbec6ec150bff5ef9ab48e5ac459d3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-duplicate-input.test.mts</strong><dd><code>Test duplicate UTXO spend rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/security-duplicate-input.test.mts

<ul><li>Adds duplicate-input security regression test.<br> <li> Builds a transaction spending one UTXO twice.<br> <li> Mines a malicious block containing it.<br> <li> Verifies block rejection and unchanged receiver balance.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/9/files#diff-93db32cd84bbfdec2385685414a73e41f4910040f21686d72ba437b6dcb13b4e">+68/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

