### PR TITLE
Preserve UTXOs across reorg recalculation

### DIFF
--- a/src/infra/node/node.mts
+++ b/src/infra/node/node.mts
@@ -624,7 +624,15 @@ export class Node {
     const uTxOuts: { [txidAndOutIndex: string]: UTxOut } = {}
     const uTxOutId = (input: TxIn | UTxOut) => `${input.txid}:${input.index}`
 
-    for (let block: Block | null = Block.deserialize(Block.GENESIS_BLOCK); block != null && block !== fork.next; block = block.next) {
+    const confirmedBlocks: Block[] = []
+    for (let block: Block | undefined = fork; block != null; block = this.blocks.get(hex(block.prev))) {
+      confirmedBlocks.push(block)
+      if (block.height === 0) {
+        break
+      }
+    }
+
+    for (const block of confirmedBlocks.reverse()) {
       for (let tx of block.transactions) {
         const referencedUTxOuts: (UTxOut | undefined)[] = tx.inputs.map(input => uTxOuts[uTxOutId(input)])
         if (referencedUTxOuts.includes(undefined)) {
@@ -633,6 +641,10 @@ export class Node {
 
         referencedUTxOuts.forEach(uTxOut => delete uTxOuts[uTxOutId(uTxOut!)])
         UTxOut.fromTransaction(block.hash(), tx).forEach(uTxOut => uTxOuts[uTxOutId(uTxOut)] = uTxOut)
+      }
+
+      if (block.height > 0) {
+        UTxOut.fromTransaction(block.hash(), block.coinbase).forEach(uTxOut => uTxOuts[uTxOutId(uTxOut)] = uTxOut)
       }
     }
 

--- a/test/security-reorg-utxo.test.mts
+++ b/test/security-reorg-utxo.test.mts
@@ -1,0 +1,55 @@
+import { afterEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { Node } from "../src/infra/node/node.mts"
+import { Account } from "../src/domain/transaction/account.mts"
+import { Block } from "../src/domain/block/block.mts"
+import { Transaction } from "../src/domain/transaction/transaction.mts"
+import { COINBASE_REWARD } from "../src/app/config.mts"
+
+describe("security: reorg UTXO recalculation", () => {
+  let node: Node | undefined
+
+  afterEach(() => {
+    node?.stop()
+    node = undefined
+  })
+
+  it("preserves UTXOs before the fork point when replacing a branch", async () => {
+    const miner = new Account()
+    node = new Node()
+    node.importAccount(miner)
+    node.start(0)
+
+    const sharedBlock = await node.mineAsync(new TextEncoder().encode("shared"))
+    assert.ok(sharedBlock)
+
+    const replacedBlock = await node.mineAsync(new TextEncoder().encode("replaced"))
+    assert.ok(replacedBlock)
+    assert.equal(node.getBalance(miner.publicKey), COINBASE_REWARD * 2)
+
+    const replacementBlock = await mineChildBlock(sharedBlock, miner, "replacement")
+    await node["onNewBlock"](replacementBlock)
+
+    assert.deepEqual(node.current.hash(), replacementBlock.hash())
+    assert.equal(
+      node.getBalance(miner.publicKey),
+      COINBASE_REWARD * 2,
+      "reorg must keep the shared pre-fork coinbase UTXO and add the replacement block coinbase"
+    )
+  })
+})
+
+async function mineChildBlock(prev: Block, miner: Account, data: string): Promise<Block> {
+  const block = prev.generate({ difficulty: prev.difficulty })
+  const coinbase = Transaction.buildCoinbaseTx(
+    miner.publicKey,
+    COINBASE_REWARD,
+    block.height,
+    new TextEncoder().encode(data)
+  )
+
+  assert.equal(block.addTransaction(coinbase), true)
+  const mined = await block.mine()
+  assert.ok(mined)
+  return mined
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test for branch replacement preserving pre-fork UTXOs
- rebuild UTXO state from the actual confirmed chain up to the fork point
- include confirmed coinbase outputs during reorg recalculation

## Verification
- pnpm exec tsx --test test/security-reorg-utxo.test.mts
- pnpm test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Rebuild UTXOs from confirmed ancestry

- Preserve pre-fork coinbase outputs

- Add reorg regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fork["Fork block"] 
  ancestry["Confirmed ancestry scan"]
  utxos["Rebuilt UTXO set"]
  replacement["Replacement branch validation"]
  balance["Preserved miner balance"]
  fork -- "walk back to genesis" --> ancestry
  ancestry -- "collect tx and coinbase outputs" --> utxos
  utxos -- "validate new blocks" --> replacement
  replacement -- "keeps shared rewards" --> balance
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node.mts</strong><dd><code>Rebuild reorg UTXOs from confirmed ancestry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/node/node.mts

<ul><li>Rebuilds UTXOs from the actual confirmed fork ancestry.<br> <li> Walks backward from <code>fork</code> to genesis, then replays forward.<br> <li> Adds confirmed non-genesis coinbase outputs during recalculation.<br> <li> Uses recalculated UTXOs when validating replacement blocks.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/10/files#diff-b9ef608958cb7a976ad2967c87ee24d48cfbec6ec150bff5ef9ab48e5ac459d3">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-reorg-utxo.test.mts</strong><dd><code>Add reorg UTXO preservation regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/security-reorg-utxo.test.mts

<ul><li>Adds regression coverage for reorg UTXO preservation.<br> <li> Mines a shared block, replaced block, and replacement child.<br> <li> Verifies the replacement branch becomes the current tip.<br> <li> Asserts shared pre-fork coinbase balance remains spendable.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/10/files#diff-2e5e9eb8faa007742be798ebf7d2b6b0b11210f7049c96a2315073a29b628ecc">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

