### PR TITLE
Reject future timestamps in downloaded chains

### DIFF
--- a/src/infra/node/node.mts
+++ b/src/infra/node/node.mts
@@ -527,6 +527,10 @@ export class Node {
 
     // validate blocks
     for (let block: Block | null = start; block != null; block = block.next) {
+      if (block.ts >= Date.now() + MAX_FUTURE_DRIFT_IN_MILLS) {
+        throw new Error('Block timestamp too far in the future')
+      }
+
       const duration = prev.ts - last(block, 10).ts
       const expectedDifficulty = this.getExpectedDifficulty(prev, duration)
 

--- a/test/security-future-timestamp.test.mts
+++ b/test/security-future-timestamp.test.mts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { randomBytes } from "node:crypto"
+import { Node } from "../src/infra/node/node.mts"
+import { Account } from "../src/domain/transaction/account.mts"
+import { Block } from "../src/domain/block/block.mts"
+import { Transaction } from "../src/domain/transaction/transaction.mts"
+import { COINBASE_REWARD, MAX_FUTURE_DRIFT_IN_MILLS } from "../src/app/config.mts"
+import { hex } from "../src/util/crypto.mts"
+
+describe("security: block timestamps", () => {
+  it("rejects a downloaded chain when any intermediate block is too far in the future", () => {
+    const node = new Node()
+    const miner = new Account()
+    const futureBlock = buildChildBlock(
+      node.current,
+      miner,
+      Date.now() + MAX_FUTURE_DRIFT_IN_MILLS + 60_000,
+      "future",
+      node["getCurrentDifficulty"]()
+    )
+    const normalTip = buildChildBlock(futureBlock, miner, Date.now(), "normal tip", futureBlock.difficulty)
+    futureBlock.connect(normalTip)
+    const downloadedBlocks = {
+      [hex(futureBlock.hash())]: futureBlock,
+      [hex(normalTip.hash())]: normalTip
+    }
+
+    assert.throws(
+      () => node["validateNewBlocksAndUpdateUTxOuts"](downloadedBlocks, futureBlock, normalTip),
+      /future/i
+    )
+  })
+})
+
+function buildChildBlock(prev: Block, miner: Account, ts: number, data: string, difficulty: number): Block {
+  const block = prev.generate({ difficulty })
+  const coinbase = Transaction.buildCoinbaseTx(
+    miner.publicKey,
+    COINBASE_REWARD,
+    block.height,
+    new TextEncoder().encode(data)
+  )
+
+  assert.equal(block.addTransaction(coinbase), true)
+  block.setTs(ts)
+  mineWithFixedTimestamp(block)
+  return block
+}
+
+function mineWithFixedTimestamp(block: Block): void {
+  while (block.isProofInvalid()) {
+    block.setNonce(randomBytes(32))
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test where an intermediate downloaded block is too far in the future while the tip is normal
- validate future timestamp drift for every block in an incoming chain, not only the tip

## Verification
- pnpm exec tsx --test test/security-future-timestamp.test.mts
- pnpm test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reject future timestamps in downloaded chains

- Validate every incoming block timestamp

- Add regression coverage for intermediate blocks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  incoming["Downloaded chain"] --> validation["Per-block timestamp validation"]
  validation -- "too far future" --> reject["Reject chain"]
  validation -- "valid timestamps" --> utxo["Continue UTxO validation"]
  test["Regression test"] -- "covers" --> validation
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node.mts</strong><dd><code>Validate timestamps for all downloaded blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/node/node.mts

<ul><li>Adds future timestamp drift validation inside the downloaded-chain <br>block loop.<br> <li> Rejects any block whose <code>ts</code> exceeds <code>Date.now() + </code><br><code>MAX_FUTURE_DRIFT_IN_MILLS</code>.<br> <li> Ensures intermediate blocks are checked, not only the chain tip.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/11/files#diff-b9ef608958cb7a976ad2967c87ee24d48cfbec6ec150bff5ef9ab48e5ac459d3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-future-timestamp.test.mts</strong><dd><code>Test rejection of future intermediate timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/security-future-timestamp.test.mts

<ul><li>Adds a security regression test for downloaded chain timestamp <br>validation.<br> <li> Builds a chain with a future-dated intermediate block and normal tip.<br> <li> Asserts <code>validateNewBlocksAndUpdateUTxOuts</code> rejects the chain.<br> <li> Includes helpers for mining blocks with fixed timestamps.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/11/files#diff-cc3d4ab6d16cfc4f38392a9d6a5881ac599cf3d88e406bd5595da996af62f49e">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

