### PR TITLE
Validate transaction structure before acceptance

### DIFF
--- a/src/domain/transaction/transaction.mts
+++ b/src/domain/transaction/transaction.mts
@@ -78,6 +78,20 @@ class Input {
   public static buildCoinbaseTxIn(blockHeight: number, data?: Uint8Array): Input {
     return new Input('0'.repeat(64), blockHeight, data ?? new Uint8Array())
   }
+
+  public assertValidSpendReference(): void {
+    if (!/^[0-9a-f]{64}$/i.test(this._txid) || this._txid === '0'.repeat(64)) {
+      throw new Error('Invalid transaction input txid')
+    }
+
+    if (!Number.isSafeInteger(this._index) || this._index < 0 || this._index > 0xffffffff) {
+      throw new Error('Invalid transaction input index')
+    }
+  }
+
+  public isCoinbaseAtHeight(blockHeight: number): boolean {
+    return this._txid === '0'.repeat(64) && this._index === blockHeight
+  }
 }
 export const TxIn = Input
 export type TxIn = Input
@@ -124,6 +138,16 @@ class Output {
 
   public static buildCoinbaseTxOut(toPubKey: Uint8Array, reward: number): Output {
     return new Output(reward, toPubKey)
+  }
+
+  public assertValidStructure(): void {
+    if (!Number.isSafeInteger(this._amount) || this._amount < 0) {
+      throw new Error('Invalid transaction output amount')
+    }
+
+    if (this._publicKey.length !== 65 || this._publicKey[0] !== 0x04) {
+      throw new Error('Invalid transaction output public key')
+    }
   }
 }
 export const TxOut = Output
@@ -293,5 +317,30 @@ export class Transaction {
     tx.addInput(Input.buildCoinbaseTxIn(blockHeight, data))
     tx.addOutput(Output.buildCoinbaseTxOut(toPubKey, reward))
     return tx
+  }
+
+  public assertValidRegularStructure(): void {
+    if (this._inputs.length === 0) {
+      throw new Error('Transaction must have at least one input')
+    }
+
+    if (this._outputs.length === 0) {
+      throw new Error('Transaction must have at least one output')
+    }
+
+    this._inputs.forEach(input => input.assertValidSpendReference())
+    this._outputs.forEach(output => output.assertValidStructure())
+  }
+
+  public assertValidCoinbaseStructure(blockHeight: number): void {
+    if (
+      this._inputs.length !== 1 ||
+      !this._inputs[0].isCoinbaseAtHeight(blockHeight) ||
+      this._outputs.length !== 1
+    ) {
+      throw new Error('Invalid coinbase transaction')
+    }
+
+    this._outputs[0].assertValidStructure()
   }
 }

--- a/src/infra/node/node.mts
+++ b/src/infra/node/node.mts
@@ -537,6 +537,8 @@ export class Node {
       // validate transactions
       let totalFee = 0
       for (let tx of block.transactions) {
+        tx.assertValidRegularStructure()
+
         // assert tx inputs all refer to unspent outputs
         const referencedUTxOuts: (UTxOut | undefined)[] = tx.inputs.map(input => uTxOuts.get(input))
         if (referencedUTxOuts.includes(undefined)) {
@@ -577,9 +579,7 @@ export class Node {
 
       // validate coinbase transaction
       const coinbase = block.coinbase
-      if (coinbase.inputs.length !== 1 || coinbase.inputs[0].index !== block.height || coinbase.outputs.length !== 1) {
-        throw new Error('Invalid coinbase transaction')
-      }
+      coinbase.assertValidCoinbaseStructure(block.height)
 
       const maxCoinbaseOut = this.getCoinbaseRewardAtHeight(block.height) + totalFee
       if (coinbase.outputs[0].amount > maxCoinbaseOut) {
@@ -703,6 +703,7 @@ export class Node {
     for (const serializedTx of response.txs) {
       try {
         const incomingTx = Transaction.deserialize(hexBytes(serializedTx))
+        incomingTx.assertValidRegularStructure()
 
         // assert tx inputs all refer to unspent outputs
         const referencedUTxOuts: (UTxOut | undefined)[] = incomingTx.inputs.map(input => this.uTxOuts.get(input))

--- a/test/security-transaction-shape.test.mts
+++ b/test/security-transaction-shape.test.mts
@@ -1,0 +1,62 @@
+import { afterEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { Node } from "../src/infra/node/node.mts"
+import { Account } from "../src/domain/transaction/account.mts"
+import { Block } from "../src/domain/block/block.mts"
+import { Transaction, TxIn, TxOut } from "../src/domain/transaction/transaction.mts"
+import { UTxOut } from "../src/domain/transaction/utxo.mts"
+import { COINBASE_REWARD } from "../src/app/config.mts"
+
+describe("security: transaction shape validation", () => {
+  let node: Node | undefined
+
+  afterEach(() => {
+    node?.stop()
+    node = undefined
+  })
+
+  it("rejects a block containing a transaction output with an invalid public key encoding", async () => {
+    const sender = new Account()
+    node = new Node()
+    node.importAccount(sender)
+    node.start(0)
+
+    const fundingBlock = await node.mineAsync(new TextEncoder().encode("fund sender"))
+    assert.ok(fundingBlock)
+
+    const spendable = node.getUnspentOutputs(sender.publicKey)[0]
+    assert.ok(spendable)
+
+    const invalidPublicKey = new Uint8Array(65)
+    const tx = buildTransactionToInvalidPublicKey(sender, spendable, invalidPublicKey)
+    const block = await mineBlockWithTransactions(node, sender, [tx])
+
+    await node["onNewBlock"](block)
+
+    assert.notDeepEqual(node.current.hash(), block.hash())
+    assert.equal(node.getBalance(invalidPublicKey), 0)
+  })
+})
+
+function buildTransactionToInvalidPublicKey(sender: Account, spendable: UTxOut, invalidPublicKey: Uint8Array): Transaction {
+  const tx = new Transaction()
+    .addInput(new TxIn(spendable.txid, spendable.index))
+    .addOutput(new TxOut(spendable.output.amount - 1_000, invalidPublicKey))
+
+  sender.signTxIn(tx, 0)
+  return tx
+}
+
+async function mineBlockWithTransactions(node: Node, miner: Account, transactions: Transaction[]): Promise<Block> {
+  const block = node.current.generate({ difficulty: node["getCurrentDifficulty"]() })
+  const coinbase = Transaction.buildCoinbaseTx(miner.publicKey, COINBASE_REWARD, block.height)
+
+  assert.equal(block.addTransaction(coinbase), true)
+  for (const tx of transactions) {
+    assert.equal(block.addTransaction(tx), true)
+  }
+
+  const mined = await block.mine()
+  assert.ok(mined)
+  return mined
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test for accepting an output with invalid public key encoding
- move regular and coinbase transaction shape checks onto Transaction
- validate transaction shape during block acceptance and mempool intake

## Verification
- pnpm exec tsx --test test/security-transaction-shape.test.mts
- pnpm test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Centralize transaction structure validation

- Reject malformed block transactions earlier

- Validate incoming mempool transactions

- Add invalid public-key regression test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tx["Transaction structure helpers"]
  block["Block acceptance"]
  mempool["Mempool intake"]
  reject["Reject malformed transactions"]
  test["Security regression test"]
  tx -- "validates" --> block
  tx -- "validates" --> mempool
  block -- "prevents" --> reject
  mempool -- "prevents" --> reject
  test -- "covers" --> reject
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction.mts</strong><dd><code>Add transaction structure validation helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/domain/transaction/transaction.mts

<ul><li>Adds input spend-reference validation for txid and index.<br> <li> Adds coinbase input height matching helper.<br> <li> Adds output structure validation for amount and public-key encoding.<br> <li> Adds regular and coinbase transaction structure assertions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/12/files#diff-b7422e5f19c2dde0535e0078464a90d35d261dae07eb35a506f66bcf60e6b383">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node.mts</strong><dd><code>Enforce transaction validation in node intake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/node/node.mts

<ul><li>Validates regular transaction structure during block acceptance.<br> <li> Replaces inline coinbase shape checks with transaction-level <br>validation.<br> <li> Validates deserialized incoming transactions before mempool UTxO <br>checks.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/12/files#diff-b9ef608958cb7a976ad2967c87ee24d48cfbec6ec150bff5ef9ab48e5ac459d3">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-transaction-shape.test.mts</strong><dd><code>Test rejection of invalid output keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/security-transaction-shape.test.mts

<ul><li>Adds regression coverage for malformed output public keys.<br> <li> Mines a block containing an invalid recipient public key.<br> <li> Asserts the node rejects the block and preserves balances.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/12/files#diff-3e08bcc495078d58bd797da05e3ac22b2fdb22baa61c1ccedc7d1ded4210b13d">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

