### PR TITLE
Let cumulative work decide lower-height forks

### DIFF
--- a/src/infra/node/node.mts
+++ b/src/infra/node/node.mts
@@ -352,7 +352,7 @@ export class Node {
   }
 
   private async onNewBlock(block: Block): Promise<void> {
-    if (this.blocks.get(hex(block.hash())) || this.tip.height > block.height) {
+    if (this.blocks.get(hex(block.hash()))) {
       return
     }
 

--- a/test/security-chain-selection.test.mts
+++ b/test/security-chain-selection.test.mts
@@ -1,0 +1,50 @@
+import { afterEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { Node } from "../src/infra/node/node.mts"
+import { Account } from "../src/domain/transaction/account.mts"
+import { Block } from "../src/domain/block/block.mts"
+import { Transaction } from "../src/domain/transaction/transaction.mts"
+import { COINBASE_REWARD } from "../src/app/config.mts"
+
+describe("security: chain selection", () => {
+  let node: Node | undefined
+
+  afterEach(() => {
+    node?.stop()
+    node = undefined
+  })
+
+  it("does not discard a lower-height fork before cumulative work validation", async () => {
+    const miner = new Account()
+    node = new Node()
+    node.importAccount(miner)
+    node.start(0)
+
+    await node.mineAsync(new TextEncoder().encode("local 1"))
+    await node.mineAsync(new TextEncoder().encode("local 2"))
+    assert.equal(node.current.height, 2)
+
+    const lowerHeightCandidate = await mineChildBlock(
+      Block.deserialize(Block.GENESIS_BLOCK),
+      miner,
+      node["getCurrentDifficulty"]()
+    )
+
+    node["validateDifficulty"] = () => undefined
+    node["validateAndRecalculateUTxOuts"] = () => undefined
+
+    await node["onNewBlock"](lowerHeightCandidate)
+
+    assert.deepEqual(node.current.hash(), lowerHeightCandidate.hash())
+  })
+})
+
+async function mineChildBlock(prev: Block, miner: Account, difficulty: number): Promise<Block> {
+  const block = prev.generate({ difficulty })
+  const coinbase = Transaction.buildCoinbaseTx(miner.publicKey, COINBASE_REWARD, block.height)
+
+  assert.equal(block.addTransaction(coinbase), true)
+  const mined = await block.mine()
+  assert.ok(mined)
+  return mined
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test showing lower-height forks should reach cumulative work validation
- remove the height-based early return from single-block acceptance

## Verification
- pnpm exec tsx --test test/security-chain-selection.test.mts
- pnpm test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Allow lower-height fork validation

- Let cumulative work choose chain

- Add chain-selection regression test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming block"] --> B["Reject duplicate hashes"]
  B --> C["Validate candidate fork"]
  C --> D["Cumulative work chain selection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node.mts</strong><dd><code>Allow lower-height block validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/node/node.mts

<ul><li>Removes the <code>this.tip.height > block.height</code> early return in <code>onNewBlock</code>.<br> <li> Allows lower-height blocks to proceed into orphan handling and <br>validation.<br> <li> Ensures cumulative work, not height alone, determines accepted chain <br>tips.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/14/files#diff-b9ef608958cb7a976ad2967c87ee24d48cfbec6ec150bff5ef9ab48e5ac459d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-chain-selection.test.mts</strong><dd><code>Add lower-height fork regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/security-chain-selection.test.mts

<ul><li>Adds a security regression test for chain selection.<br> <li> Mines a local two-block chain, then submits a lower-height candidate.<br> <li> Stubs validation internals to isolate <code>onNewBlock</code> behavior.<br> <li> Asserts the lower-height candidate can become the current tip.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/blockchain/pull/14/files#diff-201339e2b3e007842eabd7ef13e9e4b6f275977103e6b83a6965c1cdbdf4dc3a">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

